### PR TITLE
Fix Effect fetch loop: autocomplete titles should treat empty as loaded

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -257,9 +257,9 @@ fn ensure_titles_loaded(app_state: &AppContext, ac: &AutocompleteCtx) {
         return;
     }
 
-    if ac.titles_cache_db.get_untracked().as_deref() == Some(db_id.as_str())
-        && !ac.titles_cache.get_untracked().is_empty()
-    {
+    // Treat empty title lists as a valid loaded state.
+    // Otherwise, when the backend returns no navs/notes, we would refetch on every keystroke.
+    if ac.titles_cache_db.get_untracked().as_deref() == Some(db_id.as_str()) {
         return;
     }
 


### PR DESCRIPTION
When wiki-link autocomplete needs titles, it loads notes + get-all-navs titles. The previous guard only skipped reloads if the cache was non-empty, which causes repeated fetches when the backend legitimately returns zero items.

Fix: treat an empty title list as a valid loaded state keyed by titles_cache_db. This prevents refetch on every keystroke while still allowing "create new page" suggestions.